### PR TITLE
Preserve annotations

### DIFF
--- a/plugins/org.jnario/src/org/jnario/impl/JnarioMemberImpl.java
+++ b/plugins/org.jnario/src/org/jnario/impl/JnarioMemberImpl.java
@@ -19,29 +19,32 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EDataTypeEList;
 import org.eclipse.xtext.common.types.JvmVisibility;
+import org.eclipse.xtext.xbase.annotations.xAnnotations.XAnnotation;
 import org.jnario.JnarioAnnotationTarget;
+import org.jnario.JnarioFactory;
 import org.jnario.JnarioMember;
 import org.jnario.JnarioPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Member</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '
+ * <em><b>Member</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link org.jnario.impl.JnarioMemberImpl#getModifiers <em>Modifiers</em>}</li>
- *   <li>{@link org.jnario.impl.JnarioMemberImpl#getAnnotationInfo <em>Annotation Info</em>}</li>
+ * <li>{@link org.jnario.impl.JnarioMemberImpl#getModifiers <em>Modifiers</em>}</li>
+ * <li>{@link org.jnario.impl.JnarioMemberImpl#getAnnotationInfo <em>Annotation
+ * Info</em>}</li>
  * </ul>
  * </p>
  *
  * @generated
  */
-public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements JnarioMember {
+public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements
+		JnarioMember {
 	/**
-	 * The cached value of the '{@link #getModifiers() <em>Modifiers</em>}' attribute list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getModifiers() <em>Modifiers</em>}'
+	 * attribute list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getModifiers()
 	 * @generated
 	 * @ordered
@@ -49,9 +52,10 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	protected EList<String> modifiers;
 
 	/**
-	 * The cached value of the '{@link #getAnnotationInfo() <em>Annotation Info</em>}' containment reference.
-	 * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getAnnotationInfo()
+	 * <em>Annotation Info</em>}' containment reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #getAnnotationInfo()
 	 * @generated
 	 * @ordered
@@ -59,8 +63,8 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	protected JnarioAnnotationTarget annotationInfo;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected JnarioMemberImpl() {
@@ -68,8 +72,8 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -78,20 +82,21 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public EList<String> getModifiers() {
 		if (modifiers == null) {
-			modifiers = new EDataTypeEList<String>(String.class, this, JnarioPackage.JNARIO_MEMBER__MODIFIERS);
+			modifiers = new EDataTypeEList<String>(String.class, this,
+					JnarioPackage.JNARIO_MEMBER__MODIFIERS);
 		}
 		return modifiers;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public JnarioAnnotationTarget getAnnotationInfo() {
@@ -99,144 +104,161 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetAnnotationInfo(JnarioAnnotationTarget newAnnotationInfo, NotificationChain msgs) {
+	public NotificationChain basicSetAnnotationInfo(
+			JnarioAnnotationTarget newAnnotationInfo, NotificationChain msgs) {
 		JnarioAnnotationTarget oldAnnotationInfo = annotationInfo;
 		annotationInfo = newAnnotationInfo;
 		if (eNotificationRequired()) {
-			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO, oldAnnotationInfo, newAnnotationInfo);
-			if (msgs == null) msgs = notification; else msgs.add(notification);
+			ENotificationImpl notification = new ENotificationImpl(this,
+					Notification.SET,
+					JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO,
+					oldAnnotationInfo, newAnnotationInfo);
+			if (msgs == null)
+				msgs = notification;
+			else
+				msgs.add(notification);
 		}
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void setAnnotationInfo(JnarioAnnotationTarget newAnnotationInfo) {
 		if (newAnnotationInfo != annotationInfo) {
 			NotificationChain msgs = null;
 			if (annotationInfo != null)
-				msgs = ((InternalEObject)annotationInfo).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO, null, msgs);
+				msgs = ((InternalEObject) annotationInfo).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE
+								- JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO,
+						null, msgs);
 			if (newAnnotationInfo != null)
-				msgs = ((InternalEObject)newAnnotationInfo).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO, null, msgs);
+				msgs = ((InternalEObject) newAnnotationInfo).eInverseAdd(this,
+						EOPPOSITE_FEATURE_BASE
+								- JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO,
+						null, msgs);
 			msgs = basicSetAnnotationInfo(newAnnotationInfo, msgs);
-			if (msgs != null) msgs.dispatch();
-		}
-		else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO, newAnnotationInfo, newAnnotationInfo));
+			if (msgs != null)
+				msgs.dispatch();
+		} else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET,
+					JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO,
+					newAnnotationInfo, newAnnotationInfo));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated NOT
 	 */
 	public boolean isStatic() {
-		for(String modifier: getModifiers()) { 
-			if(equal(modifier, "static")) 
+		for (String modifier : getModifiers()) {
+			if (equal(modifier, "static"))
 				return true;
 		}
 		return false;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
+	public NotificationChain eInverseRemove(InternalEObject otherEnd,
+			int featureID, NotificationChain msgs) {
 		switch (featureID) {
-			case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
-				return basicSetAnnotationInfo(null, msgs);
+		case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
+			return basicSetAnnotationInfo(null, msgs);
 		}
 		return super.eInverseRemove(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
-			case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
-				return getModifiers();
-			case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
-				return getAnnotationInfo();
+		case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
+			return getModifiers();
+		case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
+			return getAnnotationInfo();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
-			case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
-				getModifiers().clear();
-				getModifiers().addAll((Collection<? extends String>)newValue);
-				return;
-			case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
-				setAnnotationInfo((JnarioAnnotationTarget)newValue);
-				return;
+		case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
+			getModifiers().clear();
+			getModifiers().addAll((Collection<? extends String>) newValue);
+			return;
+		case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
+			setAnnotationInfo((JnarioAnnotationTarget) newValue);
+			return;
 		}
 		super.eSet(featureID, newValue);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
-			case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
-				getModifiers().clear();
-				return;
-			case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
-				setAnnotationInfo((JnarioAnnotationTarget)null);
-				return;
+		case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
+			getModifiers().clear();
+			return;
+		case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
+			setAnnotationInfo((JnarioAnnotationTarget) null);
+			return;
 		}
 		super.eUnset(featureID);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
-			case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
-				return modifiers != null && !modifiers.isEmpty();
-			case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
-				return annotationInfo != null;
+		case JnarioPackage.JNARIO_MEMBER__MODIFIERS:
+			return modifiers != null && !modifiers.isEmpty();
+		case JnarioPackage.JNARIO_MEMBER__ANNOTATION_INFO:
+			return annotationInfo != null;
 		}
 		return super.eIsSet(featureID);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public String toString() {
-		if (eIsProxy()) return super.toString();
+		if (eIsProxy())
+			return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (modifiers: ");
@@ -246,27 +268,27 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated NOT
 	 */
 	public JvmVisibility getDeclaredVisibility() {
-		for(String modifier: getModifiers()) {
-			if(equal(modifier, "public")) 
+		for (String modifier : getModifiers()) {
+			if (equal(modifier, "public"))
 				return JvmVisibility.PUBLIC;
-			if(equal(modifier, "package")) 
+			if (equal(modifier, "package"))
 				return JvmVisibility.DEFAULT;
-			if(equal(modifier, "protected")) 
+			if (equal(modifier, "protected"))
 				return JvmVisibility.PROTECTED;
-			if(equal(modifier, "private")) 
+			if (equal(modifier, "private"))
 				return JvmVisibility.PRIVATE;
 		}
 		return null;
 	}
-	
+
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated NOT
 	 */
 	public JvmVisibility getDefaultVisibility() {
@@ -274,44 +296,58 @@ public class JnarioMemberImpl extends JnarioAnnotationTargetImpl implements Jnar
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated NOT
 	 */
 	public boolean isTransient() {
-		for(String modifier: getModifiers()) { 
-			if(equal(modifier, "abstract")) 
+		for (String modifier : getModifiers()) {
+			if (equal(modifier, "abstract"))
 				return false;
-			if(equal(modifier, "final")) 
+			if (equal(modifier, "final"))
 				return true;
 		}
 		return false;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated NOT
 	 */
 	public boolean isFinal() {
-		for(String modifier: getModifiers()) { 
-			if(equal(modifier, "abstract")) 
+		for (String modifier : getModifiers()) {
+			if (equal(modifier, "abstract"))
 				return false;
-			if(equal(modifier, "final")) 
+			if (equal(modifier, "final"))
 				return true;
 		}
 		return false;
 	}
 
-
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated NOT
 	 */
 	public JvmVisibility getVisibility() {
 		JvmVisibility declaredVisibility = getDeclaredVisibility();
-		return declaredVisibility == null ? getDefaultVisibility() : declaredVisibility;
+		return declaredVisibility == null ? getDefaultVisibility()
+				: declaredVisibility;
 	}
 
-} //JnarioMemberImpl
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public EList<XAnnotation> getAnnotations() {
+		if (getAnnotationInfo() == null) {
+			setAnnotationInfo(JnarioFactory.eINSTANCE
+					.createJnarioAnnotationTarget());
+		}
+		return getAnnotationInfo().getAnnotations();
+	}
+
+} // JnarioMemberImpl

--- a/releng/org.jnario.target/luna.target
+++ b/releng/org.jnario.target/luna.target
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="luna" sequenceNumber="86">
+<?pde version="3.8"?><target name="luna" sequenceNumber="92">
 <locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.m2e.feature.feature.group" version="1.5.1.20150109-1820"/>
+<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/releases/luna/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.xtend.sdk.feature.group" version="2.8.3.v201506010551"/>
+<unit id="org.eclipse.xtext.sdk.feature.group" version="2.8.3.v201506010551"/>
+<unit id="org.eclipse.xtext.redist.feature.group" version="2.8.3.v201506010551"/>
+<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.pde.core" version="0.0.0"/>
+<unit id="org.eclipse.pde.ui" version="0.0.0"/>
+<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.4"/>
+</location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.guava" version="15.0.0.v201403281430"/>
 <unit id="com.google.inject" version="0.0.0"/>
@@ -32,26 +50,8 @@
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.m2e.feature.feature.group" version="1.5.0.20140606-0033"/>
-<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/luna/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.jdt.junit.runners.feature.feature.group" version="0.1.0.201409041622"/>
-<repository location="http://download.eclipse.org/eclipse_jdt_junit_runners/updatesite/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xtend.sdk.feature.group" version="2.8.1.v201503230617"/>
-<unit id="org.eclipse.xtext.sdk.feature.group" version="2.8.1.v201503230617"/>
-<unit id="org.eclipse.xtext.redist.feature.group" version="2.8.1.v201503230617"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.pde.core" version="0.0.0"/>
-<unit id="org.eclipse.pde.ui" version="0.0.0"/>
-<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.4"/>
+<unit id="org.eclipse.jdt.junit.runners.feature.feature.group" version="0.1.0.201411181552"/>
+<repository location="http://www.xpect-tests.org/updatesite/nightly/"/>
 </location>
 </locations>
 <launcherArgs>


### PR DESCRIPTION
The problem of the missing @Injects was that the generators used the getAnnotations()-methods while the annotations were in the getAnnotationInfo().getAnnotations().

Changed the JnarioMemberImpl to redirect to the getAnnotationInfo().getAnnotations().
I updated the luna-target platform as well because the junit-runner dependency could not be found anymore.

Are you still actively working on that branch? We use jnario quite a lot in my company and now we face a bit a problem :-) So it looks like some guys from my team will definitely try to contribute.

best regards
Mathias
